### PR TITLE
Update debian playbook

### DIFF
--- a/tasks/os_family/Debian.yml
+++ b/tasks/os_family/Debian.yml
@@ -13,6 +13,9 @@
 - name: install docker-compose
   pip: name=docker-compose
 
+- name: install docker-py
+  pip: name=docker-py
+
 - name: adding apt-key
   shell: curl -sSL https://get.docker.com/gpg | sudo apt-key add -
 

--- a/tasks/os_family/Debian.yml
+++ b/tasks/os_family/Debian.yml
@@ -3,21 +3,22 @@
   apt: name={{ item }} state=latest
   with_items:
     - python
-    - python-pip
     - curl
     - apt-transport-https
     - ca-certificates
     - apparmor
-    - linux-image-generic
+
+- name: install pip
+  shell: curl -sSL https://bootstrap.pypa.io/get-pip.py | python
 
 - name: install docker-compose
-  pip: name=docker-compose
+  shell: curl -sSL https://github.com/docker/compose/releases/download/1.6.2/run.sh > /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose
 
 - name: install docker-py
   pip: name=docker-py
 
 - name: adding apt-key
-  shell: curl -sSL https://get.docker.com/gpg | sudo apt-key add -
+  shell: curl -sSL https://get.docker.com/gpg | apt-key add -
 
 - name: docker package
   shell: curl -sSL https://get.docker.com/ | sh


### PR DESCRIPTION
- package linux-image-generic removed:  does not exist and is not needed
- package pyhton-pip replaced by get-pip.py
- replaced docker-compose pip package by the docker-compose inside a container script
- sudo not needed because all the tasks are run by root
