### PR TITLE
fix to avoid "No Package matching 'python-pip'"

### DIFF
--- a/tasks/os_family/RedHat.yml
+++ b/tasks/os_family/RedHat.yml
@@ -12,7 +12,9 @@
     - python-docker-py
 
 - name: making sure pip installed
-  yum: name=python-pip state=present
+  shell: curl https://bootstrap.pypa.io/get-pip.py | python - ;
+  become: yes
+  become_user: root
 
 - name: Install docker-compose through pip
   pip: name=docker-compose state=latest


### PR DESCRIPTION
In order to avoid this error on RedHat family

```
TASK [abaez.docker : making sure pip installed] ********************************
fatal: [192.168.13.37]: FAILED! => {"changed": false, "failed": true, "msg": "No Package matching 'python-pip' found available, installed or updated", "rc": 0, "results": []}
        to retry, use: --limit @ansible/playbook.retry
```
