### PR TITLE
Fixed typo in RedHat.yml

### DIFF
--- a/tasks/os_family/RedHat.yml
+++ b/tasks/os_family/RedHat.yml
@@ -6,7 +6,7 @@
 
 - name: Run the RedHat based install
   include: "RHEL.yml"
-  when: ansible_distribution == "Redhat"
+  when: ansible_distribution == "RedHat"
 
 - name: Run the Centos based install
   include: "CentOS.yml"


### PR DESCRIPTION
It is RedHat, not Redhat.